### PR TITLE
Bump pandas, numpy, python verisions.

### DIFF
--- a/bin/conda_env.yml
+++ b/bin/conda_env.yml
@@ -2,8 +2,9 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - python=3.8.8
-  - pandas
+  - python=3.13
+  - pandas>=2.2.0
+  - numpy>=2.0.0
   - pip:
     - xmltodict
     - requests


### PR DESCRIPTION
I am proposing an update to the default conda environment for the workflow template to bring us up to date with the most recent version of Python. Also, this environment enforces numpy >= 2.0.